### PR TITLE
Implement object-based deck with placeholder descriptions

### DIFF
--- a/deck.json
+++ b/deck.json
@@ -1,14 +1,17 @@
 {
-  "deck": [
-    "Extra Move",
-    "Block Road",
-    "Hidden Path",
-    "Double Back",
-    "Fake Ticket",
-    "Stealth Mode",
-    "Change Line",
-    "Swap Position",
-    "Decoy",
-    "Secret Route"
+  "cards": [
+    {"title": "Red Time Bonus", "description": "temp", "amount": 25},
+    {"title": "Orange Time Bonus", "description": "temp", "amount": 15},
+    {"title": "Yellow Time Bonus", "description": "temp", "amount": 10},
+    {"title": "Green Time Bonus", "description": "temp", "amount": 3},
+    {"title": "Blue Time Bonus", "description": "temp", "amount": 2},
+    {"title": "Randomize", "description": "temp", "amount": 4},
+    {"title": "Veto", "description": "temp", "amount": 4},
+    {"title": "Duplicate", "description": "temp", "amount": 2},
+    {"title": "Move", "description": "temp", "amount": 1},
+    {"title": "Discard 1 Draw 2", "description": "temp", "amount": 4},
+    {"title": "Discard 2 Draw 3", "description": "temp", "amount": 4},
+    {"title": "Draw 1 Expand 1", "description": "temp", "amount": 2},
+    {"title": "Temp Curse", "description": "temp", "amount": 24}
   ]
 }

--- a/script.js
+++ b/script.js
@@ -10,7 +10,12 @@ function loadDeck() {
         fetch('deck.json')
             .then(r => r.json())
             .then(data => {
-                deck = data.deck;
+                deck = [];
+                data.cards.forEach(cardType => {
+                    for (let i = 0; i < cardType.amount; i++) {
+                        deck.push({ title: cardType.title, description: cardType.description });
+                    }
+                });
                 saveState();
                 updateDeckCount();
             });
@@ -47,7 +52,13 @@ function renderHand() {
     hand.forEach((card, index) => {
         const cardDiv = document.createElement('div');
         cardDiv.className = 'card';
-        cardDiv.textContent = card;
+        const title = document.createElement('div');
+        title.className = 'card-title';
+        title.textContent = card.title;
+        const desc = document.createElement('p');
+        desc.textContent = card.description;
+        cardDiv.appendChild(title);
+        cardDiv.appendChild(desc);
         const discardBtn = document.createElement('button');
         discardBtn.textContent = 'X';
         discardBtn.onclick = () => {

--- a/style.css
+++ b/style.css
@@ -44,6 +44,11 @@ button {
     position: relative;
 }
 
+.card-title {
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
 .card button {
     position: absolute;
     top: 5px;


### PR DESCRIPTION
## Summary
- restructure the card deck format to use objects with `title`, `description`, and `amount`
- generate deck from these objects on load
- show card titles and descriptions in the hand view
- style card titles for clarity

## Testing
- `python3 -m json.tool deck.json`

------
https://chatgpt.com/codex/tasks/task_e_68685397b6e08330bf2842eaea452687