### PR TITLE
Add fullscreen card display

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,14 @@
         <button id="back-from-seeker">Back</button>
     </div>
 
+    <div id="card-overlay" class="hidden">
+        <div class="overlay-content">
+            <button id="close-overlay">X</button>
+            <h2 id="overlay-title"></h2>
+            <p id="overlay-description"></p>
+        </div>
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,16 @@ let deck = [];
 let hand = [];
 let questions = {};
 
+function showCardOverlay(card) {
+    document.getElementById('overlay-title').textContent = card.title;
+    document.getElementById('overlay-description').textContent = card.description;
+    document.getElementById('card-overlay').classList.remove('hidden');
+}
+
+function hideCardOverlay() {
+    document.getElementById('card-overlay').classList.add('hidden');
+}
+
 function loadDeck() {
     if (localStorage.getItem('deck')) {
         deck = JSON.parse(localStorage.getItem('deck'));
@@ -52,13 +62,11 @@ function renderHand() {
     hand.forEach((card, index) => {
         const cardDiv = document.createElement('div');
         cardDiv.className = 'card';
+        cardDiv.onclick = () => showCardOverlay(card);
         const title = document.createElement('div');
         title.className = 'card-title';
         title.textContent = card.title;
-        const desc = document.createElement('p');
-        desc.textContent = card.description;
         cardDiv.appendChild(title);
-        cardDiv.appendChild(desc);
         if (card.cost) {
             const cost = document.createElement('p');
             cost.className = 'card-cost';
@@ -67,7 +75,8 @@ function renderHand() {
         }
         const discardBtn = document.createElement('button');
         discardBtn.textContent = 'X';
-        discardBtn.onclick = () => {
+        discardBtn.onclick = (e) => {
+            e.stopPropagation();
             const [discarded] = hand.splice(index, 1);
             if (discarded) {
                 deck.push(discarded);
@@ -125,6 +134,8 @@ document.getElementById('choose-hider').onclick = () => {
 document.getElementById('choose-seeker').onclick = () => {
     showScreen('seeker-screen');
 };
+
+document.getElementById('close-overlay').onclick = hideCardOverlay;
 
 document.getElementById('back-from-hider').onclick = () => showScreen('role-selection');
 

--- a/style.css
+++ b/style.css
@@ -42,6 +42,8 @@ button {
     padding: 10px;
     margin: 5px;
     position: relative;
+    width: 180px;
+    cursor: pointer;
 }
 
 .card-title {
@@ -52,6 +54,10 @@ button {
 .card-cost {
     font-style: italic;
     margin-top: 5px;
+}
+
+.card-desc {
+    display: none;
 }
 
 .card button {
@@ -80,4 +86,37 @@ button {
 
 #questions {
     margin-top: 10px;
+}
+
+#card-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+#card-overlay .overlay-content {
+    background: white;
+    width: 90%;
+    max-width: 500px;
+    padding: 20px;
+    position: relative;
+    text-align: left;
+}
+
+#card-overlay h2 {
+    margin-top: 0;
+    font-size: 24px;
+}
+
+#card-overlay button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
 }


### PR DESCRIPTION
## Summary
- fix card layout width and add overlay for fullscreen view
- hide card description until expanded
- stop card clicks from discarding by accident

## Testing
- `python3 -m http.server` then `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_686858d612f48330b57ccc51c417ab55